### PR TITLE
Switch to alpine, expose environments from 80 port, allow websockets connections and just a little bit of documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,17 @@ RUN apk-install curl nginx \
     | tar -zxC /bin \
  && entrykit --symlink
 
-# Configure Nginx the way we want
-COPY nginx.conf /etc/nginx/nginx.conf
-
 ENV DOCKER_GEN_VERSION 0.4.0
 RUN curl -Ls https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
     | tar -C /usr/local/bin -xvz
 
 COPY . /app/
 WORKDIR /app/
+
+# Configure Nginx the way we want
+RUN rm -f /etc/nginx/nginx.conf \
+    && ln -s /app/nginx.conf /etc/nginx/nginx.conf \
+    && touch /etc/nginx/conf.d/envy.conf
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,10 @@ RUN apk-install curl nginx \
     | tar -zxC /bin \
  && entrykit --symlink
 
-# Configure Nginx and apply fix for very long server names
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+# Configure Nginx the way we want
+COPY nginx.conf /etc/nginx/nginx.conf
 
 ENV DOCKER_GEN_VERSION 0.4.0
-
 RUN curl -Ls https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
     | tar -C /usr/local/bin -xvz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,24 @@
-FROM nginx:1.9.2
+FROM gliderlabs/alpine:3.2
 MAINTAINER Greg Allen code@firstandthird.com
 
-# Install wget and install/updates certificates
-RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
-    ca-certificates \
-    wget \
- && apt-get clean \
- && rm -r /var/lib/apt/lists/*
+# Install nginx, curl and entrykit
+RUN apk-install curl nginx \
+ && curl -Ls https://github.com/progrium/entrykit/releases/download/v0.2.0/entrykit_0.2.0_Linux_x86_64.tgz \
+    | tar -zxC /bin \
+ && entrykit --symlink
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
-# Install Forego
-RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
- && chmod u+x /usr/local/bin/forego
-
 ENV DOCKER_GEN_VERSION 0.4.0
 
-RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+RUN curl -Ls https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+    | tar -C /usr/local/bin -xvz
 
 COPY . /app/
 WORKDIR /app/
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
-CMD ["forego", "start", "-r"]
+CMD ["codep", "nginx", "/app/docker-events-handler"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	docker build -t gregallen/envy-proxy .

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-nginx: nginx
-dockergen: docker-gen -watch -notify "nginx -s reload" /app/envy.tmpl /etc/nginx/conf.d/default.conf

--- a/README.md
+++ b/README.md
@@ -6,8 +6,43 @@
 * Make sure your root host has a wildcard dns entry for it
 * If you run this on port 80, you'll need to run the envy term on another port
 
-## Usage
+_:warning: `envy-proxy` currently relies on having an Envy instance with [this patch](https://github.com/progrium/envy/pull/41)
+applied :warning:_
 
+## Installation
+
+```sh
+docker run -d \
+           -v /var/run/docker.sock:/tmp/docker.sock:ro \
+           -e ROOT_HOST=example.com \
+           -p 80:80 \
+           --name envy-proxy \
+           gregallen/envy-proxy
 ```
-docker run -d -v /var/run/docker.sock:/tmp/docker.sock:ro -e ROOT_HOST=example.com -p 80:80 --name envy-proxy gregallen/envy-proxy
+
+By default, only the `80` port will be exposed, but you can pass in a comma
+separated list of ports as the`PROXY_PORTS` environmental variable to expose other
+ports as well.
+
+For example:
+
+```sh
+docker run -d \
+           -v /var/run/docker.sock:/tmp/docker.sock:ro \
+           -e ROOT_HOST=example.com \
+           -e PROXY_PORTS='80,8080,3000' \
+           -p 80:80 \
+           --name envy-proxy \
+           gregallen/envy-proxy
 ```
+
+Will allow accessing environments from `80`, `8080` and `3000` ports.
+
+## How does it work?
+
+Once started, `envy-proxy` will listen to Docker events and will set up its
+nginx instance to forward `http://<port>-<user>-<envy-environment>.<HOST_ROOT>`
+requests to the underlying Envy environment on the corresponding port.
+
+For example, if you run a web server on port `8080` from a `username+webapp@envy.host`
+session, you'll be able to reach it on your browser using `http://8080-username-webapp.<HOST_ROOT>`

--- a/docker-events-handler
+++ b/docker-events-handler
@@ -1,0 +1,5 @@
+#!/bin/sh
+docker-gen -watch \
+           -notify "nginx -s reload" \
+           /app/envy.tmpl \
+           /etc/nginx/conf.d/default.conf

--- a/docker-events-handler
+++ b/docker-events-handler
@@ -2,4 +2,4 @@
 docker-gen -watch \
            -notify "nginx -s reload" \
            /app/envy.tmpl \
-           /etc/nginx/conf.d/default.conf
+           /etc/nginx/conf.d/envy.conf

--- a/envy.tmpl
+++ b/envy.tmpl
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
   listen 80 default_server;
   server_name _; # This is just an invalid value which will never trigger on a real hostname.
@@ -30,15 +35,16 @@ server {
   access_log /proc/self/fd/1;
 
   location / {
-    proxy_pass http://{{ $environ }}_{{ $port }};
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    # HTTP 1.1 support
+    # HTTP 1.1 / WebSockets support
+    proxy_pass http://{{ $environ }}_{{ $port }};
     proxy_http_version 1.1;
-    proxy_set_header Connection "";
+    proxy_set_header Upgrade    $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
   }
 }
 {{ end }}

--- a/envy.tmpl
+++ b/envy.tmpl
@@ -11,6 +11,10 @@ server {
 
 {{ range $environ, $containers := groupByMulti $ "Labels.envy" "," }}
 
+###############################################################################
+# Configs for {{ $environ }}:{{ $port }}
+{{ $environ := replace $environ "." "-" -1 }}
+
 upstream {{ $environ }}_{{ $port }} {
   {{ range $container := $containers }}
     server {{ $container.IP }}:{{ $port }};
@@ -19,8 +23,8 @@ upstream {{ $environ }}_{{ $port }} {
 server {
   gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-  listen {{ $port }};
-  server_name {{ $environ }}.{{ $.Env.ROOT_HOST }};
+  listen 80;
+  server_name {{ $port }}-{{ $environ }}.{{ $.Env.ROOT_HOST }};
   proxy_buffering off;
   error_log /proc/self/fd/2;
   access_log /proc/self/fd/1;

--- a/envy.tmpl
+++ b/envy.tmpl
@@ -1,8 +1,3 @@
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
-
 server {
   listen 80 default_server;
   server_name _; # This is just an invalid value which will never trigger on a real hostname.
@@ -35,16 +30,7 @@ server {
   access_log /proc/self/fd/1;
 
   location / {
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    # HTTP 1.1 / WebSockets support
     proxy_pass http://{{ $environ }}_{{ $port }};
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade    $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
   }
 }
 {{ end }}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+daemon off;
+worker_processes  1;
+error_log /dev/stdout notice;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  server_names_hash_bucket_size 128;
+  include           mime.types;
+  default_type      application/octet-stream;
+  sendfile          on;
+  keepalive_timeout 65;
+  gzip              on;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /dev/stdout main;
+
+  include /etc/nginx/conf.d/envy.conf;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,5 +19,38 @@ http {
     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log /dev/stdout main;
 
+  # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+  # scheme used to connect to this server
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+  }
+
+  # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+  # Connection header that may have been passed to this server
+  map $http_upgrade $proxy_connection {
+    default upgrade;
+    '' close;
+  }
+
+  gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+  log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+    '"$request" $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent"';
+
+  access_log /proc/self/fd/1 vhost;
+  error_log /proc/self/fd/2;
+
+  # HTTP 1.1 support
+  proxy_http_version 1.1;
+  proxy_buffering off;
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+
   include /etc/nginx/conf.d/envy.conf;
 }


### PR DESCRIPTION
Sorry for such a big PR :grin: 
- The switch to alpine reduces the image size from ~190mb down to less than 30mb
- By exposing environments from `http://<port>-<environment>.<HOST_ROOT>` I can work around some ~~stupid~~ firewall limitations I face on a couple WiFi networks I regularly access :muscle: 
- WebSockets support increases the range of projects we can use with envy + envy-proxy
- Not to say that documentation is always cool :smile: 

Cheers!
